### PR TITLE
Allow pg_trgm extension to be created beforehand.

### DIFF
--- a/src/main/resources/db/migration/V1_00__initial_ddl.sql
+++ b/src/main/resources/db/migration/V1_00__initial_ddl.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION pg_trgm;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 
 CREATE SEQUENCE "hibernate_sequence";


### PR DESCRIPTION
This is necessary because old PostgreSQL versions only allow superusers
to create extensions. Trusted extensions were only introduced in
PostgreSQL 13.

Closes #28 