### PR TITLE
Remove own transaction from migration script

### DIFF
--- a/src/main/resources/db/migration/V1_00__initial_ddl.sql
+++ b/src/main/resources/db/migration/V1_00__initial_ddl.sql
@@ -1,6 +1,3 @@
-BEGIN;
-
-
 CREATE EXTENSION pg_trgm;
 
 
@@ -245,6 +242,3 @@ CREATE TABLE "news_audit" (
   PRIMARY KEY ("id", "rev"),
   FOREIGN KEY ("rev") REFERENCES "revision"("id")
 );
-
-
-COMMIT;


### PR DESCRIPTION
Since Flyway uses it own transactions, ours can be removed.
https://flywaydb.org/documentation/learnmore/faq#rollback

close #29