### PR TITLE
Improve banner picture endpoint.

### DIFF
--- a/src/main/java/com/bannergress/backend/controllers/BannerPictureController.java
+++ b/src/main/java/com/bannergress/backend/controllers/BannerPictureController.java
@@ -5,15 +5,13 @@ import com.bannergress.backend.services.BannerPictureService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.server.ResponseStatusException;
 
-import javax.servlet.http.HttpServletResponse;
-
-import java.io.IOException;
 import java.util.Optional;
 
 @Controller
@@ -21,13 +19,14 @@ public class BannerPictureController {
     @Autowired
     private BannerPictureService bannerPictureService;
 
-    @RequestMapping(value = "/banners/pictures/{hash}", method = RequestMethod.GET, produces = {"image/jpeg"})
-    public void getFile(@PathVariable String hash, HttpServletResponse response) throws IOException {
+    @GetMapping(value = "/banners/pictures/{hash}", produces = MediaType.IMAGE_JPEG_VALUE)
+    public ResponseEntity<byte[]> getFile(@PathVariable String hash) {
         Optional<BannerPicture> bannerPicture = bannerPictureService.findByHash(hash);
         if (bannerPicture.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        response.setHeader(HttpHeaders.CACHE_CONTROL, "immutable");
-        response.getOutputStream().write(bannerPicture.get().getPicture());
+        return ResponseEntity.ok().contentType(MediaType.IMAGE_JPEG)
+            .header(HttpHeaders.CACHE_CONTROL, "public, max-age=31536000, immutable")
+            .body(bannerPicture.get().getPicture());
     }
 }


### PR DESCRIPTION
Use @GetMapping instead of @RequestMapping.
Replace HttpServletResponse with ResponseEntity.
Send Chrome-compatible cache-control header and add content-type header.