### PR TITLE
Store number of banners per place in a redundant way.

### DIFF
--- a/src/main/java/com/bannergress/backend/controllers/PlaceController.java
+++ b/src/main/java/com/bannergress/backend/controllers/PlaceController.java
@@ -47,6 +47,7 @@ public class PlaceController {
         PlaceInformation information = placeService.getPlaceInformation(place, "en");
         PlaceDto placeDto = new PlaceDto();
         placeDto.id = place.getId();
+        placeDto.numberOfBanners = place.getNumberOfBanners();
         placeDto.formattedAddress = information.getFormattedAddress();
         placeDto.longName = information.getLongName();
         placeDto.shortName = information.getShortName();

--- a/src/main/java/com/bannergress/backend/dto/PlaceDto.java
+++ b/src/main/java/com/bannergress/backend/dto/PlaceDto.java
@@ -8,4 +8,6 @@ public class PlaceDto {
     public String longName;
 
     public String shortName;
+
+    public int numberOfBanners;
 }

--- a/src/main/java/com/bannergress/backend/entities/Place.java
+++ b/src/main/java/com/bannergress/backend/entities/Place.java
@@ -30,6 +30,9 @@ public class Place {
     @Enumerated(EnumType.STRING)
     private PlaceType type;
 
+    @Column(name = "number_of_banners", nullable = false)
+    private int numberOfBanners;
+
     /**
      * Language-specific information.
      */
@@ -58,5 +61,13 @@ public class Place {
 
     public void setInformation(List<PlaceInformation> information) {
         this.information = information;
+    }
+
+    public int getNumberOfBanners() {
+        return numberOfBanners;
+    }
+
+    public void setNumberOfBanners(int numberOfBanners) {
+        this.numberOfBanners = numberOfBanners;
     }
 }

--- a/src/main/java/com/bannergress/backend/services/impl/BannerServiceImpl.java
+++ b/src/main/java/com/bannergress/backend/services/impl/BannerServiceImpl.java
@@ -166,6 +166,7 @@ public class BannerServiceImpl implements BannerService {
             Collection<Place> startPlaces = geocodingService.getPlaces(startLatitude, startLongitude);
             banner.getStartPlaces().clear();
             banner.getStartPlaces().addAll(startPlaces);
+            banner.getStartPlaces().forEach(place -> place.setNumberOfBanners(place.getNumberOfBanners() + 1));
         }
         banner.setLengthMeters(distance);
         bannerPictureService.refresh(banner);

--- a/src/main/resources/db/migration/V1_00__initial_ddl.sql
+++ b/src/main/resources/db/migration/V1_00__initial_ddl.sql
@@ -51,6 +51,7 @@ CREATE INDEX ON "banner" USING gin ((lower("title")) gin_trgm_ops);
 CREATE TABLE "place" (
   "id" text NOT NULL,
   "type" place_type NOT NULL,
+  "number_of_banners" integer NOT NULL,
   PRIMARY KEY ("id")
 );
 CREATE INDEX ON "place" ("type");


### PR DESCRIPTION
This is needed for an acceptable performance when querying places.

Closes #54 