### PR TITLE
Allow store

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+  web:
+    resources:
+      cache:
+        cachecontrol:
+          no-store: false
 
 keycloak:
   bearer-only: true


### PR DESCRIPTION
This allows clients to store responses in their local cache and therefore allows for smaller 304 answers with the already-enabled ETags.
Spring is still sending the max-age: 0 directive, so the answer is considered stale from the beginning and has to be revalidated on every request.

Closes #67 