### PR TITLE
Update banners using events.

### DIFF
--- a/src/main/java/com/bannergress/backend/event/BannerChangedEvent.java
+++ b/src/main/java/com/bannergress/backend/event/BannerChangedEvent.java
@@ -1,0 +1,18 @@
+package com.bannergress.backend.event;
+
+import com.bannergress.backend.entities.Banner;
+
+/**
+ * Event that fires when a banner is changed.
+ */
+public class BannerChangedEvent {
+    private final Banner banner;
+
+    public BannerChangedEvent(Banner banner) {
+        this.banner = banner;
+    }
+
+    public Banner getBanner() {
+        return banner;
+    }
+}

--- a/src/main/java/com/bannergress/backend/event/BannerRecalculationListeners.java
+++ b/src/main/java/com/bannergress/backend/event/BannerRecalculationListeners.java
@@ -1,0 +1,51 @@
+package com.bannergress.backend.event;
+
+import com.bannergress.backend.entities.Banner;
+import com.bannergress.backend.services.BannerPictureService;
+import com.bannergress.backend.services.BannerService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+
+@Component
+public class BannerRecalculationListeners {
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private BannerService bannerService;
+
+    @Autowired
+    private BannerPictureService bannerPictureService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    void onPOIChanged(POIChangedEvent event) {
+        TypedQuery<Banner> query = entityManager.createQuery(
+            "SELECT b FROM Banner b JOIN b.missions m JOIN m.steps s JOIN s WHERE s.poi = :poi", Banner.class);
+        query.setParameter("poi", event.getPoi());
+        query.getResultList().stream().forEach((banner) -> {
+            bannerService.calculateData(banner);
+        });
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    void onMissionChanged(MissionChangedEvent event) {
+        TypedQuery<Banner> query = entityManager
+            .createQuery("SELECT b FROM Banner b WHERE :mission MEMBER OF b.missions", Banner.class);
+        query.setParameter("mission", event.getMission());
+        query.getResultList().stream().forEach((banner) -> {
+            bannerService.calculateData(banner);
+            bannerPictureService.refresh(banner);
+        });
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void onBannerChanged(BannerChangedEvent event) {
+        bannerService.calculateData(event.getBanner());
+        bannerPictureService.refresh(event.getBanner());
+    }
+}

--- a/src/main/java/com/bannergress/backend/event/MissionChangedEvent.java
+++ b/src/main/java/com/bannergress/backend/event/MissionChangedEvent.java
@@ -1,0 +1,18 @@
+package com.bannergress.backend.event;
+
+import com.bannergress.backend.entities.Mission;
+
+/**
+ * Event that fires when a mission is changed.
+ */
+public class MissionChangedEvent {
+    private final Mission mission;
+
+    public MissionChangedEvent(Mission mission) {
+        this.mission = mission;
+    }
+
+    public Mission getMission() {
+        return mission;
+    }
+}

--- a/src/main/java/com/bannergress/backend/event/POIChangedEvent.java
+++ b/src/main/java/com/bannergress/backend/event/POIChangedEvent.java
@@ -1,0 +1,18 @@
+package com.bannergress.backend.event;
+
+import com.bannergress.backend.entities.POI;
+
+/**
+ * Event that fires when a POI is changed.
+ */
+public class POIChangedEvent {
+    private final POI poi;
+
+    public POIChangedEvent(POI poi) {
+        this.poi = poi;
+    }
+
+    public POI getPoi() {
+        return poi;
+    }
+}

--- a/src/main/java/com/bannergress/backend/services/BannerService.java
+++ b/src/main/java/com/bannergress/backend/services/BannerService.java
@@ -6,7 +6,6 @@ import com.bannergress.backend.enums.BannerSortOrder;
 import com.bannergress.backend.exceptions.MissionAlreadyUsedException;
 import org.springframework.data.domain.Sort.Direction;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -58,22 +57,16 @@ public interface BannerService {
     void update(UUID uuid, BannerDto bannerDto);
 
     /**
-     * Updates information of all banners that contain one of the specified missions.
-     *
-     * @param missionIds Mission IDs.
-     */
-    void updateBannersContainingMission(Collection<String> missionIds);
-
-    /**
-     * Updates information of all banners that contain one of the specified POIs.
-     *
-     * @param missionIds POI IDs.
-     */
-    void updateBannersContainingPOI(Collection<String> poiIds);
-
-    /**
      * Deletes a banner by UUID.
+     *
      * @param uuid UUID to delete.
      */
     void deleteByUuid(UUID uuid);
+
+    /**
+     * Calculates derived data of a banner.
+     *
+     * @param banner Banner.
+     */
+    void calculateData(Banner banner);
 }


### PR DESCRIPTION
All banner recalculations now happen immediately before the transaction
ends.