### PR TITLE
Make width in audit table nullable.

### DIFF
--- a/src/main/resources/db/migration/V1_00__initial_ddl.sql
+++ b/src/main/resources/db/migration/V1_00__initial_ddl.sql
@@ -191,7 +191,7 @@ CREATE TABLE "banner_audit" (
   "description" text,
   "title" text,
   "type" banner_type,
-  "width" integer NOT NULL,
+  "width" integer,
   PRIMARY KEY ("uuid", "rev"),
   FOREIGN KEY ("rev") REFERENCES "revision"("id")
 );


### PR DESCRIPTION
Except for the primary key columns, audit table columns must all be nullable because DELETE audit entries contain NULL values.