### PR TITLE
Improve unused mission performance.

### DIFF
--- a/src/main/java/com/bannergress/backend/entities/Mission.java
+++ b/src/main/java/com/bannergress/backend/entities/Mission.java
@@ -112,6 +112,13 @@ public class Mission {
     @NotAudited
     private Instant latestUpdateDetails;
 
+    /**
+     * List of banners in which the mission is included.
+     */
+    @ManyToMany(mappedBy = "missions")
+    @NotAudited
+    private List<Banner> banners;
+
     public String getId() {
         return id;
     }

--- a/src/main/java/com/bannergress/backend/services/impl/MissionServiceImpl.java
+++ b/src/main/java/com/bannergress/backend/services/impl/MissionServiceImpl.java
@@ -203,7 +203,7 @@ public class MissionServiceImpl implements MissionService {
                                                   Direction orderDirection, int offset, int limit) {
         String queryString = "SELECT m FROM Mission m WHERE (LOWER(m.title) LIKE :search "
             + "OR LOWER(m.author.name) = :searchExact)"
-            + "AND NOT EXISTS (SELECT b FROM Banner b WHERE m MEMBER OF b.missions)";
+            + "AND m.banners IS EMPTY";
         if (orderBy.isPresent()) {
             switch (orderBy.get()) {
                 case title:


### PR DESCRIPTION
Hibernate creates poor SQL query. For a faster SQL query, we need the
reverse mapping of missions to banners.