### PR TITLE
Fix quotes in config

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,7 +12,7 @@ spring:
     hibernate:
       ddl-auto: none
     properties:
-      hibernate.globally_quoted_identifiers: true
+      '[hibernate.globally_quoted_identifiers]': true
   web:
     resources:
       cache:
@@ -44,6 +44,6 @@ keycloak:
 
 logging:
   level:
-    com.bannergress: DEBUG
-    org.hibernate.SQL: DEBUG # DEBUG for SQL queries
-    org.hibernate.type: INFO # TRACE for SQL parameters
+    '[com.bannergress]': DEBUG
+    '[org.hibernate.SQL]': DEBUG # DEBUG for SQL queries
+    '[org.hibernate.type]': INFO # TRACE for SQL parameters


### PR DESCRIPTION
Eclipse produces warnings for unquoted special characters like '.'