### PR TITLE
Allow to disable online status when importing mission details.

### DIFF
--- a/src/main/java/com/bannergress/backend/controllers/ImportController.java
+++ b/src/main/java/com/bannergress/backend/controllers/ImportController.java
@@ -8,6 +8,7 @@ import com.bannergress.backend.services.IntelImportService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.annotation.security.RolesAllowed;
@@ -45,8 +46,9 @@ public class ImportController {
 
     @RolesAllowed(Roles.IMPORT_DATA)
     @PostMapping("/import/details")
-    public Map<String, MissionStatus> importMissionDetails(@RequestBody @Valid IntelMissionDetails data) {
-        Mission mission = intelImportService.importMission(data);
+    public Map<String, MissionStatus> importMissionDetails(@RequestBody @Valid IntelMissionDetails data,
+                                                           @RequestParam(defaultValue = "true") boolean setStatusOnline) {
+        Mission mission = intelImportService.importMission(data, setStatusOnline);
         return toStatusMap(List.of(mission));
     }
 

--- a/src/main/java/com/bannergress/backend/entities/Mission.java
+++ b/src/main/java/com/bannergress/backend/entities/Mission.java
@@ -96,7 +96,7 @@ public class Mission {
      * Mission status.
      */
     @Column(name = "online", nullable = false)
-    private boolean online = true;
+    private boolean online;
 
     /**
      * Timestamp when the mission summary was last updated.

--- a/src/main/java/com/bannergress/backend/services/IntelImportService.java
+++ b/src/main/java/com/bannergress/backend/services/IntelImportService.java
@@ -18,10 +18,11 @@ public interface IntelImportService {
     /**
      * Imports a mission from intel-based data.
      *
-     * @param data Intel response data.
+     * @param data            Intel response data.
+     * @param setStatusOnline Set status of mission to online.
      * @return Imported mission.
      */
-    Mission importMission(IntelMissionDetails data);
+    Mission importMission(IntelMissionDetails data, boolean setStatusOnline);
 
     /**
      * Imports missions from intel-based data.

--- a/src/main/java/com/bannergress/backend/services/impl/IntelImportServiceImpl.java
+++ b/src/main/java/com/bannergress/backend/services/impl/IntelImportServiceImpl.java
@@ -26,7 +26,7 @@ public class IntelImportServiceImpl extends BaseImportServiceImpl implements Int
     private static final int INTEL_TOP_MISSIONS_FOR_PORTAL_LIMIT = 10;
 
     @Override
-    public Mission importMission(IntelMissionDetails data) {
+    public Mission importMission(IntelMissionDetails data, boolean setMissionOnline) {
         return withRecalculation(tracker -> {
             Mission mission = importMissionSummary(data, tracker);
             setMissionAuthor(mission, data.authorName, data.authorFaction);
@@ -38,7 +38,7 @@ public class IntelImportServiceImpl extends BaseImportServiceImpl implements Int
             for (int i = 0; i < steps.size(); i++) {
                 importMissionStep(steps.get(i), mission.getSteps().get(i), tracker);
             }
-            setMissionOnline(mission, null, tracker);
+            setMissionOnline(mission, setMissionOnline ? true : null, tracker);
             entityManager.persist(mission);
             return mission;
         });


### PR DESCRIPTION
When importing, it is now possible to specify whether the mission should
be assumed online (default and previous behaviour) or no assumptions
about the status should be made.
This allows imports of missions that are already offline.