### PR TITLE
Do not delete pictures on banner deletion.

### DIFF
--- a/src/main/java/com/bannergress/backend/entities/Banner.java
+++ b/src/main/java/com/bannergress/backend/entities/Banner.java
@@ -137,7 +137,7 @@ public class Banner {
     /**
      * Generated Picture.
      */
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "picture")
     @NotAudited
     private BannerPicture picture;

--- a/src/main/java/com/bannergress/backend/services/BannerPictureService.java
+++ b/src/main/java/com/bannergress/backend/services/BannerPictureService.java
@@ -18,5 +18,12 @@ public interface BannerPictureService {
 
     Optional<BannerPicture> findByHash(String hash);
 
+    /**
+     * Sets a picture as expired.
+     *
+     * @param picture Picture, may be <code>null</code>.
+     */
+    void setPictureExpired(BannerPicture picture);
+
     void removeExpired();
 }

--- a/src/main/java/com/bannergress/backend/services/impl/BannerPictureServiceImpl.java
+++ b/src/main/java/com/bannergress/backend/services/impl/BannerPictureServiceImpl.java
@@ -75,9 +75,7 @@ public class BannerPictureServiceImpl implements BannerPictureService {
     @Override
     public void refresh(Banner banner) {
         BannerPicture oldPicture = banner.getPicture();
-        if (oldPicture != null) {
-            oldPicture.setExpiration(Instant.now().plusSeconds(60));
-        }
+        setPictureExpired(oldPicture);
         String hash = hash(banner);
         BannerPicture newPicture = entityManager.find(BannerPicture.class, hash);
         if (newPicture == null) {
@@ -215,6 +213,13 @@ public class BannerPictureServiceImpl implements BannerPictureService {
     @Override
     public Optional<BannerPicture> findByHash(String hash) {
         return Optional.ofNullable(entityManager.find(BannerPicture.class, hash));
+    }
+
+    @Override
+    public void setPictureExpired(BannerPicture picture) {
+        if (picture != null) {
+            picture.setExpiration(Instant.now().plusSeconds(3_600));
+        }
     }
 
     @Override

--- a/src/main/java/com/bannergress/backend/services/impl/BannerServiceImpl.java
+++ b/src/main/java/com/bannergress/backend/services/impl/BannerServiceImpl.java
@@ -237,7 +237,7 @@ public class BannerServiceImpl implements BannerService {
     @Override
     public Banner generatePreview(BannerDto bannerDto) throws MissionAlreadyUsedException {
         Banner banner = createTransient(bannerDto, bannerDto.id != null ? List.of(bannerDto.id) : List.of());
-        banner.getPicture().setExpiration(Instant.now().plusSeconds(3_600));
+        pictureService.setPictureExpired(banner.getPicture());
         return banner;
     }
 
@@ -262,6 +262,7 @@ public class BannerServiceImpl implements BannerService {
     @Override
     public void deleteBySlug(String slug) {
         Banner banner = bannerRepository.findOne(BannerSpecifications.hasSlug(slug)).get();
+        pictureService.setPictureExpired(banner.getPicture());
         for (Place place : banner.getStartPlaces()) {
             place.setNumberOfBanners(place.getNumberOfBanners() - 1);
         }


### PR DESCRIPTION
A picture may be used by more than one banner, so cascading the DELETE will potentially fail the banner deletion.

Closes #225 