### PR TITLE
Fix the import of "unknown" players.

### DIFF
--- a/src/main/java/com/bannergress/backend/dto/serialization/IntelMissionDetailsDeserializer.java
+++ b/src/main/java/com/bannergress/backend/dto/serialization/IntelMissionDetailsDeserializer.java
@@ -28,8 +28,8 @@ public class IntelMissionDetailsDeserializer extends JsonDeserializer<IntelMissi
         result.id = array.get(0).textValue();
         result.title = array.get(1).textValue();
         result.description = array.get(2).textValue();
+        result.authorName = array.get(3).textValue();
         if (!array.get(4).textValue().equals("N")) {
-            result.authorName = array.get(3).textValue();
             result.authorFaction = parseFaction(array.get(4).textValue());
         }
         result.ratingE6 = array.get(5).asInt();

--- a/src/main/java/com/bannergress/backend/services/impl/BaseImportServiceImpl.java
+++ b/src/main/java/com/bannergress/backend/services/impl/BaseImportServiceImpl.java
@@ -24,6 +24,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 public abstract class BaseImportServiceImpl {
+    private static final String AUTHOR_UNKNOWN = "unknown";
+
     @Autowired
     private AgentService agentService;
 
@@ -48,14 +50,13 @@ public abstract class BaseImportServiceImpl {
         return mission;
     }
 
-    /**
-     * @param mission
-     * @param newAuthor
-     * @param newAuthorFaction
-     */
     protected final void setMissionAuthor(Mission mission, String newAuthor, Faction newAuthorFaction) {
         if (newAuthor != null) {
-            mission.setAuthor(agentService.importAgent(newAuthor, newAuthorFaction));
+            if (newAuthor.equalsIgnoreCase(AUTHOR_UNKNOWN)) {
+                mission.setAuthor(null);
+            } else {
+                mission.setAuthor(agentService.importAgent(newAuthor, newAuthorFaction));
+            }
         }
     }
 

--- a/src/test/java/com/bannergress/backend/dto/serialization/TestIntelMissionDetailsDeserializer.java
+++ b/src/test/java/com/bannergress/backend/dto/serialization/TestIntelMissionDetailsDeserializer.java
@@ -53,7 +53,7 @@ public class TestIntelMissionDetailsDeserializer {
         ObjectMapper mapper = new ObjectMapper();
         IntelMissionDetails details = mapper.readValue(data, IntelMissionDetails.class);
         assertThat(details.authorFaction).isNull();
-        assertThat(details.authorName).isNull();
+        assertThat(details.authorName).isEqualTo("unknown");
     }
 
     @Test


### PR DESCRIPTION
"unknown" (Intel) or "UNKNOWN" (mission creator) indicates that the agent has been deleted.

Closes #234 