### PR TITLE
Fix casing of official author names.

### DIFF
--- a/src/main/java/com/bannergress/backend/services/impl/BannerServiceImpl.java
+++ b/src/main/java/com/bannergress/backend/services/impl/BannerServiceImpl.java
@@ -47,11 +47,11 @@ import java.util.stream.Stream;
 @Transactional
 public class BannerServiceImpl implements BannerService {
     private static final List<String> OFFICIAL_MISSION_AUTHORS = ImmutableList.of( //
-        "MissionByNia", //
-        "MissionsByNIA", //
+        "MissionbyNIA", //
+        "MissionsbyNIA", //
         "MissionDaysNia", //
         "MissionsNIA", //
-        "MDNia2", //
+        "MDNIA2", //
         "MDNIA", //
         "MDNIA2020" //
     );


### PR DESCRIPTION
Since we search for author names in a case-sensitive fashion, correct casing is mandatory.

Closes #251 