### PR TITLE
Separate keycloak configuration and keycloak web security configuration.

### DIFF
--- a/src/main/java/com/bannergress/backend/config/KeycloakConfiguration.java
+++ b/src/main/java/com/bannergress/backend/config/KeycloakConfiguration.java
@@ -1,0 +1,17 @@
+package com.bannergress.backend.config;
+
+import org.keycloak.adapters.KeycloakConfigResolver;
+import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/** Basic keycloak configuration. */
+@Configuration
+@Profile("!dev")
+public class KeycloakConfiguration {
+    @Bean
+    public KeycloakConfigResolver keycloakConfigResolver() {
+        return new KeycloakSpringBootConfigResolver();
+    }
+}

--- a/src/main/java/com/bannergress/backend/security/KeycloakSecurityConfig.java
+++ b/src/main/java/com/bannergress/backend/security/KeycloakSecurityConfig.java
@@ -1,7 +1,5 @@
 package com.bannergress.backend.security;
 
-import org.keycloak.adapters.KeycloakConfigResolver;
-import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
 import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +14,7 @@ import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper
 import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 
+/** Keycloak web security configuration. */
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(jsr250Enabled = true, prePostEnabled = true)
@@ -38,10 +37,5 @@ public class KeycloakSecurityConfig extends KeycloakWebSecurityConfigurerAdapter
     @Bean
     protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
         return new NullAuthenticatedSessionStrategy();
-    }
-
-    @Bean
-    public KeycloakConfigResolver keycloakConfigResolver() {
-        return new KeycloakSpringBootConfigResolver();
     }
 }


### PR DESCRIPTION
Spring Boot 2.6 does not allow circular dependencies anymore by default.
Since the `KeycloakWebSecurityConfigurerAdapter` base class autowires the `KeycloakConfigResolver`, we have to configure the `KeycloakConfigResolver` in a different class.