### PR TITLE
Remove hibernate.dialect setting

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,6 @@ spring:
       ddl-auto: none
     properties:
       hibernate.globally_quoted_identifiers: true
-      hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
       hibernate.search.backend.directory.root: searchindex/
       hibernate.id.db_structure_naming_strategy: single
       org.hibernate.envers.audit_table_suffix: _audit


### PR DESCRIPTION
This removes the warning "HHH90000025: PostgreSQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)"